### PR TITLE
feat(datasets): enhance dataset structure and functionality

### DIFF
--- a/ssl_backdoor/attacks/drupe/datasets.py
+++ b/ssl_backdoor/attacks/drupe/datasets.py
@@ -17,7 +17,7 @@ from torchvision import datasets, transforms
 
 from ssl_backdoor.datasets.dataset import FileListDataset
 from ssl_backdoor.datasets import dataset_params
-from ssl_backdoor.datasets.agent import BadEncoderPoisoningAgent
+from ssl_backdoor.datasets.attacker.agent import BadEncoderPoisoningAgent
 from ssl_backdoor.datasets.utils import add_watermark
 from ssl_backdoor.attacks.badencoder.datasets import BadEncoderDataset
 from ssl_backdoor.attacks.badencoder.datasets import get_poisoning_dataset

--- a/ssl_backdoor/datasets/__init__.py
+++ b/ssl_backdoor/datasets/__init__.py
@@ -1,4 +1,4 @@
 from .utils import Trigger_Dataset, ReferenceObjectDataset
 from .var import dataset_params
-
+from .dataset import FileListDataset
 from .utils import add_watermark, concatenate_images

--- a/ssl_backdoor/datasets/attacker/__init__.py
+++ b/ssl_backdoor/datasets/attacker/__init__.py
@@ -1,0 +1,20 @@
+"""攻击/投毒相关实现（从 datasets 层拆分出来）。
+
+该子包用于容纳各类 poisoning agent、生成器网络以及 CorruptEncoder 辅助函数。
+"""
+
+from .agent import (
+    CTRLPoisoningAgent,
+    AdaptivePoisoningAgent,
+    BadEncoderPoisoningAgent,
+    BadCLIPPoisoningAgent,
+    ExternalServicePoisoningAgent,
+)
+
+__all__ = [
+    "CTRLPoisoningAgent",
+    "AdaptivePoisoningAgent",
+    "BadEncoderPoisoningAgent",
+    "BadCLIPPoisoningAgent",
+    "ExternalServicePoisoningAgent",
+]

--- a/ssl_backdoor/datasets/attacker/corruptencoder_utils.py
+++ b/ssl_backdoor/datasets/attacker/corruptencoder_utils.py
@@ -8,6 +8,7 @@ import errno
 import random
 import numpy as np
 
+
 def get_trigger(trigger_size=40, trigger_path=None, colorful_trigger=True):
     # load trigger
     if colorful_trigger:
@@ -20,7 +21,7 @@ def get_trigger(trigger_size=40, trigger_path=None, colorful_trigger=True):
 
 def binary_mask_to_box(binary_mask):
     binary_mask = np.array(binary_mask, np.uint8)
-    contours,hierarchy = cv2.findContours(
+    contours, hierarchy = cv2.findContours(
         binary_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
     areas = []
     for cnt in contours:
@@ -31,6 +32,7 @@ def binary_mask_to_box(binary_mask):
     bounding_box = [x, y, x+w, y+h]
     return bounding_box
 
+
 # def get_foreground(reference_dir, num_references, max_size, type):
 #     img_idx = random.choice(range(1, 1+num_references))
 #     image_path = os.path.join(reference_dir, f'{img_idx}/img.png')
@@ -38,14 +40,14 @@ def binary_mask_to_box(binary_mask):
 #     image_np = np.asarray(Image.open(image_path).convert('RGB'))
 #     mask_np = np.asarray(Image.open(mask_path).convert('RGB'))
 #     mask_np = (mask_np[..., 0] == 128) ##### [:,0]==128 represents the object mask
-    
+#
 #     # crop masked region
 #     bbx = binary_mask_to_box(mask_np)
 #     object_image = image_np[bbx[1]:bbx[3],bbx[0]:bbx[2]]
 #     object_image = Image.fromarray(object_image)
 #     object_mask = mask_np[bbx[1]:bbx[3],bbx[0]:bbx[2]]
 #     object_mask = Image.fromarray(object_mask)
-
+#
 #     # resize -> avoid poisoned image being too large
 #     w, h = object_image.size
 #     if type=='horizontal':
@@ -58,30 +60,32 @@ def binary_mask_to_box(binary_mask):
 #     object_mask = object_mask.resize((o_w, o_h))
 #     return object_image, object_mask
 
+
 def get_foreground(reference_image_path, max_size, type):
     mask_path = reference_image_path.replace('img.png', 'label.png')
     image_np = np.asarray(Image.open(reference_image_path).convert('RGB'))
     mask_np = np.asarray(Image.open(mask_path).convert('RGB'))
     mask_np = (mask_np[..., 0] == 128) ##### [:,0]==128 represents the object mask
-    
+
     # crop masked region
     bbx = binary_mask_to_box(mask_np)
-    object_image = image_np[bbx[1]:bbx[3],bbx[0]:bbx[2]]
+    object_image = image_np[bbx[1]:bbx[3], bbx[0]:bbx[2]]
     object_image = Image.fromarray(object_image)
-    object_mask = mask_np[bbx[1]:bbx[3],bbx[0]:bbx[2]]
+    object_mask = mask_np[bbx[1]:bbx[3], bbx[0]:bbx[2]]
     object_mask = Image.fromarray(object_mask)
 
     # resize -> avoid poisoned image being too large
     w, h = object_image.size
-    if type=='horizontal':
+    if type == 'horizontal':
         o_w = min(w, int(max_size/2))
         o_h = int((o_w/w) * h)
-    elif type=='vertical':
+    elif type == 'vertical':
         o_h = min(h, int(max_size/2))
         o_w = int((o_h/h) * w)
     object_image = object_image.resize((o_w, o_h))
     object_mask = object_mask.resize((o_w, o_h))
     return object_image, object_mask
+
 
 def concat(support_reference_image_path, reference_image_path, max_size):
     ### horizontally concat two images
@@ -98,7 +102,7 @@ def concat(support_reference_image_path, reference_image_path, max_size):
     reference_image = reference_image.resize((width, height))
 
     img_new = Image.new("RGB", (width*2, height), "white")
-    if random.random()<0.5:
+    if random.random() < 0.5:
         img_new.paste(support_reference_image, (0, 0))
         img_new.paste(reference_image, (width, 0))
     else:
@@ -111,6 +115,7 @@ def get_random_reference_image(reference_dir, num_references):
     img_idx = random.choice(range(1, 1+num_references))
     image_path = os.path.join(reference_dir, f'{img_idx}/img.png')
     return image_path
+
 
 def get_random_support_reference_image(reference_dir):
     support_dir = os.path.join(reference_dir, 'support-images')

--- a/ssl_backdoor/datasets/attacker/generators.py
+++ b/ssl_backdoor/datasets/attacker/generators.py
@@ -16,6 +16,7 @@ from torch.autograd import Variable
 # To control feature map in generator
 ngf = 64
 
+
 class GeneratorResnet(nn.Module):
     def __init__(self, inception=False, dim="high"):
         '''
@@ -60,7 +61,6 @@ class GeneratorResnet(nn.Module):
         else:
             print("I'm under low dim module!")
 
-
         # Input size = 3, n/4, n/4
         self.upsampl1 = nn.Sequential(
             nn.ConvTranspose2d(ngf * 4, ngf * 2, kernel_size=3, stride=2, padding=1, output_padding=1, bias=False),
@@ -81,11 +81,9 @@ class GeneratorResnet(nn.Module):
             nn.Conv2d(ngf, 3, kernel_size=7, padding=0)
         )
 
-
         self.crop = nn.ConstantPad2d((0, -1, -1, 0), 0)
 
     def forward(self, input):
-
         x = self.block1(input)
         x = self.block2(x)
         x = self.block3(x)
@@ -102,7 +100,7 @@ class GeneratorResnet(nn.Module):
         if self.inception:
             x = self.crop(x)
 
-        return (torch.tanh(x) + 1) / 2 # Output range [0 1]
+        return (torch.tanh(x) + 1) / 2  # Output range [0 1]
 
 
 class GeneratorAdv(nn.Module):
@@ -118,7 +116,7 @@ class GeneratorAdv(nn.Module):
 
     def forward(self, input):
         # perturbation = (torch.tanh(self.perturbation) + 1) / 2
-        return input + self.perturbation * self.eps # Output range [0 1]
+        return input + self.perturbation * self.eps  # Output range [0 1]
 
 
 class Generator_Patch(nn.Module):
@@ -136,7 +134,7 @@ class Generator_Patch(nn.Module):
         random_x = np.random.randint(0, input.shape[-1] - self.perturbation.shape[-1])
         random_y = np.random.randint(0, input.shape[-1] - self.perturbation.shape[-1])
         input[:, :, random_x:random_x + self.perturbation.shape[-1], random_y:random_y + self.perturbation.shape[-1]] = self.perturbation
-        return input # Output range [0 1]
+        return input  # Output range [0 1]
 
 
 class ResidualBlock(nn.Module):
@@ -144,22 +142,19 @@ class ResidualBlock(nn.Module):
         super(ResidualBlock, self).__init__()
         self.block = nn.Sequential(
             nn.ReflectionPad2d(1),
-            nn.Conv2d(in_channels=num_filters, out_channels=num_filters, kernel_size=3, stride=1, padding=0,
-                      bias=False),
+            nn.Conv2d(in_channels=num_filters, out_channels=num_filters, kernel_size=3, stride=1, padding=0, bias=False),
             nn.BatchNorm2d(num_filters),
             nn.ReLU(True),
-
             nn.Dropout(0.5),
-
             nn.ReflectionPad2d(1),
-            nn.Conv2d(in_channels=num_filters, out_channels=num_filters, kernel_size=3, stride=1, padding=0,
-                      bias=False),
+            nn.Conv2d(in_channels=num_filters, out_channels=num_filters, kernel_size=3, stride=1, padding=0, bias=False),
             nn.BatchNorm2d(num_filters)
         )
 
     def forward(self, x):
         residual = self.block(x)
         return x + residual
+
 
 if __name__ == '__main__':
     netG = GeneratorResnet()

--- a/ssl_backdoor/datasets/dataset.py
+++ b/ssl_backdoor/datasets/dataset.py
@@ -16,12 +16,11 @@ from abc import abstractmethod
 
 from torch.utils import data
 
-from .corruptencoder_utils import *
-from .agent import CTRLPoisoningAgent, AdaptivePoisoningAgent, ExternalServicePoisoningAgent
+from .attacker.corruptencoder_utils import *
+from .attacker.agent import CTRLPoisoningAgent, AdaptivePoisoningAgent, ExternalServicePoisoningAgent
 from .utils import concatenate_images, attr_exists, attr_is_true, load_image, add_watermark, split_resize_transforms
 
 from .base import TriggerBasedPoisonedTrainDataset
-from .hidden import *
 from .var import dataset_params
 
 # 兼容不同Pillow版本的双线性插值常量
@@ -68,7 +67,7 @@ class CTRLTrainDataset(TriggerBasedPoisonedTrainDataset):
         return self.agent.apply_poison(image)
     
     def generate_poisoned_data(self, poison_info: 'list[dict]') -> List[str]:
-        """Generate poisoned dataset and visualize DCT domain differences."""
+        """Generate poisoned dataset."""
         poison_index = 0
         poison_list = []
 
@@ -85,96 +84,6 @@ class CTRLTrainDataset(TriggerBasedPoisonedTrainDataset):
 
                 poisoned_image.save(save_path)
                 poison_list.append(f"{save_path} {target_class}")
-
-        # Randomly select an image for DCT domain comparison
-        random_poison_info = random.choice(poison_info)
-        random_poison_path = random.choice(random_poison_info['reference_paths'])
-        trigger_path = random_poison_info['trigger_path']
-
-        # Load original and poisoned images
-        original_image = Image.open(random_poison_path).convert('RGB')
-        poisoned_image = self.apply_poison(image=random_poison_path, trigger=trigger_path)
-
-        original_image_np = np.array(original_image)
-        poisoned_image_np = np.array(poisoned_image)
-
-        # Convert images to YUV color space
-        original_yuv = self.agent.rgb_to_yuv(original_image_np)
-        poisoned_yuv = self.agent.rgb_to_yuv(poisoned_image_np)
-
-        # Prepare arrays for DCT coefficients
-        original_dct = np.zeros_like(original_yuv)
-        poisoned_dct = np.zeros_like(poisoned_yuv)
-
-        height, width, _ = original_yuv.shape
-        window_size = self.agent.window_size
-
-        # Compute DCT coefficients in windows for channels in channel_list
-        for ch in self.agent.channel_list:
-            for w in range(0, height - height % window_size, window_size):
-                for h in range(0, width - width % window_size, window_size):
-                    # Original image DCT
-                    orig_block = original_yuv[w:w + window_size, h:h + window_size, ch]
-                    orig_dct_block = self.agent.dct_2d(orig_block, norm='ortho')
-                    original_dct[w:w + window_size, h:h + window_size, ch] = orig_dct_block
-
-                    # Poisoned image DCT
-                    poison_block = poisoned_yuv[w:w + window_size, h:h + window_size, ch]
-                    poison_dct_block = self.agent.dct_2d(poison_block, norm='ortho')
-                    poisoned_dct[w:w + window_size, h:h + window_size, ch] = poison_dct_block
-
-        # Compute difference in DCT domain for the specified channels
-        dct_diff = np.zeros_like(original_dct)
-        for ch in self.agent.channel_list:
-            dct_diff[:, :, ch] = np.abs(poisoned_dct[:, :, ch] - original_dct[:, :, ch])
-        
-        # Print positions where dct_diff is not zero and their values
-        non_zero_indices = np.argwhere(dct_diff > 10)
-        for idx in non_zero_indices:
-            w, h, ch = idx
-            value = dct_diff[w, h, ch]
-            print(f">10 DCT difference at position ({w}, {h}, channel {ch}): {value}")
-
-        # Normalize and convert to uint8 for visualization
-        def normalize_and_convert(img_array):
-            min_val = np.min(img_array)
-            max_val = np.max(img_array)
-            normalized = (img_array - min_val) / (max_val - min_val + 1e-8)
-            normalized = (normalized * 255).astype(np.uint8)
-            return normalized
-
-        # Prepare visualization images
-        original_dct_vis = normalize_and_convert(original_dct)
-        poisoned_dct_vis = normalize_and_convert(poisoned_dct)
-        diff_dct_vis = normalize_and_convert(dct_diff)
-
-        # Convert arrays to images
-        original_dct_image = Image.fromarray(original_dct_vis, mode='RGB')
-        poisoned_dct_image = Image.fromarray(poisoned_dct_vis, mode='RGB')
-        diff_image = Image.fromarray(diff_dct_vis, mode='RGB')
-
-        # Ensure images have the same size
-        min_width = min(original_dct_image.width, poisoned_dct_image.width, diff_image.width)
-        min_height = min(original_dct_image.height, poisoned_dct_image.height, diff_image.height)
-        original_dct_image = original_dct_image.resize((min_width, min_height))
-        poisoned_dct_image = poisoned_dct_image.resize((min_width, min_height))
-        diff_image = diff_image.resize((min_width, min_height))
-
-        # Save diff image
-        diff_image_path = os.path.join(self.temp_path, 'diff.png')
-        diff_image.save(diff_image_path)
-        print(f"DCT domain difference image saved to {diff_image_path}")
-
-        # Create side-by-side comparison image
-        compare_width = min_width * 2
-        compare_image = Image.new('RGB', (compare_width, min_height))
-        compare_image.paste(original_dct_image, (0, 0))
-        compare_image.paste(poisoned_dct_image, (min_width, 0))
-
-        # Save comparison image
-        compare_image_path = os.path.join(self.temp_path, 'compare.png')
-        compare_image.save(compare_image_path)
-        print(f"DCT domain comparison image saved to {compare_image_path}")
 
         return poison_list
 
@@ -314,18 +223,10 @@ class BltoPoisoningPoisonedTrainDataset(TriggerBasedPoisonedTrainDataset):
     def apply_poison(self, image, trigger):
         return self.poisoning_agent.apply_poison(image)
 
-class BltoPoisoningPoisonedTrainDataset(TriggerBasedPoisonedTrainDataset):
-    def __init__(self, args, path_to_txt_file, transform):
-        self.poisoning_agent = AdaptivePoisoningAgent(args)
-        super(BltoPoisoningPoisonedTrainDataset, self).__init__(args, path_to_txt_file, transform)
-        
-    
-    def apply_poison(self, image, trigger):
-        return self.poisoning_agent.apply_poison(image)
-
 
 class SSLBackdoorTrainDataset(TriggerBasedPoisonedTrainDataset):
     def __init__(self, args, path_to_txt_file, transform):
+
         # 提前初始化 apply_poison 所需的配置字段，避免在父类 __init__ 中调用 apply_poison 时发生 AttributeError
         # 这里直接使用传入的 args，而不是依赖父类先设置 self.args
         self.args = args
@@ -335,6 +236,7 @@ class SSLBackdoorTrainDataset(TriggerBasedPoisonedTrainDataset):
 
         super(SSLBackdoorTrainDataset, self).__init__(args, path_to_txt_file, transform)
 
+        
     def apply_poison(self, image, trigger):
         triggered_img = add_watermark(image, trigger, watermark_width=self.trigger_size,
                                     position=self.position,
@@ -361,9 +263,6 @@ class ExternalBackdoorTrainDataset(TriggerBasedPoisonedTrainDataset):
 
 
 
-
-
-    
 class OnlineUniversalPoisonedValDataset(data.Dataset):
     def __init__(self, args, path_to_txt_file, transform, pre_inject_mode=False):
         # 读取文件列表
@@ -390,7 +289,7 @@ class OnlineUniversalPoisonedValDataset(data.Dataset):
             args.device = 'cpu'
             self.agent = AdaptivePoisoningAgent(args)
         elif self.args.attack_algorithm == 'badclip':
-            from .agent import BadCLIPPoisoningAgent
+            from .attacker.agent import BadCLIPPoisoningAgent
             self.agent = BadCLIPPoisoningAgent(args)
         elif self.args.attack_algorithm == 'external_backdoor':
             self.agent = ExternalServicePoisoningAgent(self.args)
@@ -405,6 +304,7 @@ class OnlineUniversalPoisonedValDataset(data.Dataset):
         self.trigger_insert = getattr(self.args, 'trigger_insert', 'patch')
         self.position = getattr(self.args, 'position', 'random')
         self.alpha = getattr(self.args, 'alpha', 0.2)
+        self.attack_algorithm = getattr(self.args, 'attack_algorithm', None)
 
 
         # 初始化投毒样本索引
@@ -430,22 +330,7 @@ class OnlineUniversalPoisonedValDataset(data.Dataset):
 
         if hasattr(self, 'agent'):
             return self.agent.apply_poison(img)
-        elif self.args.attack_algorithm == 'optimized':
-            if not hasattr(self, 'delta_np'):
-                ckpt_state = torch.load(self.args.trigger_path, map_location="cpu")
-                delta = ckpt_state['model']['delta']
-                delta = delta.mean(0).permute(1, 2, 0)
-                delta = delta * 255 * (16 / 255)
-                self.delta_np = delta.cpu().numpy()
-
-            img = img.resize(self.delta_np.shape[:2])
-            image_np = np.array(img)
-
-            poisoned_img = (image_np + self.delta_np).clip(0, 255).astype(np.uint8)
-            poisoned_img = Image.fromarray(poisoned_img)
-            poisoned_img.convert('RGB')
-            return poisoned_img
-        elif self.args.attack_algorithm == 'clean':
+        elif self.attack_algorithm == 'clean':
             return img
         else:
             # 支持基于参数的多种插入方式：watermark 或 refool
@@ -464,12 +349,12 @@ class OnlineUniversalPoisonedValDataset(data.Dataset):
 
     def inject_trigger_to_all_samples(self):
         """将触发器直接应用于所有图像，并保存数据集"""
-        poisoned_dataset_path = "/workspace/SSL-Backdoor/data/tmp/offline-poisons"
+        poisoned_dataset_path = "tmp/offline-poisons"
         if not os.path.exists(poisoned_dataset_path):
             os.makedirs(poisoned_dataset_path)
 
         # 新文件路径，用于保存更新后的配置文件
-        poisoned_file_list_path = "/workspace/SSL-Backdoor/data/tmp/poisoned_file_list.txt"
+        poisoned_file_list_path = "tmp/poisoned_file_list.txt"
 
         # 逐个处理图像并保存
         with open(poisoned_file_list_path, 'w') as f:

--- a/ssl_backdoor/datasets/dataset.py
+++ b/ssl_backdoor/datasets/dataset.py
@@ -332,6 +332,8 @@ class OnlineUniversalPoisonedValDataset(data.Dataset):
             return self.agent.apply_poison(img)
         elif self.attack_algorithm == 'clean':
             return img
+        elif self.attack_algorithm == 'optimized':
+            raise ValueError("optimized attack algorithm is not supported for OnlineUniversalPoisonedValDataset")
         else:
             # 支持基于参数的多种插入方式：watermark 或 refool
             return add_watermark(

--- a/ssl_backdoor/datasets/var.py
+++ b/ssl_backdoor/datasets/var.py
@@ -20,6 +20,11 @@ dataset_params = {
         'image_size': 224,
         'num_classes': 100,
     },
+    'imagenet20': {
+        'normalize': transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]), 
+        'image_size': 224,
+        'num_classes': 20,
+    },
     'cifar10': {
         'normalize': transforms.Normalize(mean=[0.4914, 0.4822, 0.4465], std=[0.2023, 0.1994, 0.2010]), 
         'image_size': 32,


### PR DESCRIPTION
Summary:\n- Add datasets/attacker subpackage and move poisoning agents/utilities there.\n- Add imagenet20 dataset params.\n- Improve poisoned sampling logic and external_backdoor trigger handling.\n- Minor refactors/formatting and deprecation warning.\n\nNotes:\n- This PR introduces new defaults for watermark placement (position/location_min/location_max) in base dataset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves poisoning agents/utils into a new datasets/attacker subpackage, adds configurable watermark placement and improved sampling/trigger handling, and introduces imagenet20 params.
> 
> - **Structure**:
>   - Extract poisoning code into `ssl_backdoor/datasets/attacker/` (`agent.py`, `generators.py`, `corruptencoder_utils.py`) and update imports (e.g., `datasets.py`, `dataset.py`, `__init__.py`).
> - **Datasets/Config**:
>   - Add `imagenet20` to `dataset_params`.
>   - Base `TriggerBasedPoisonedTrainDataset` adds watermark controls: `position`, `location_min`, `location_max` and default `trigger_insert`/`alpha` handling.
>   - Improve poison sampling: use `random.choices` (with replacement) or `random.sample` (without) based on `num_poison` vs available refs; allow `external_backdoor` without local trigger file.
> - **Agents**:
>   - `BadEncoderPoisoningAgent` now emits deprecation warning.
>   - New `ExternalServicePoisoningAgent` wired for train/val datasets; `ExternalBackdoorTrainDataset` added.
> - **Val/IO**:
>   - `OnlineUniversalPoisonedValDataset`: unify agent usage/imports, add `attack_algorithm` attr, set offline inject paths to `tmp/offline-poisons` and `tmp/poisoned_file_list.txt`, and reject `optimized` mode.
> - **Cleanup**:
>   - Remove DCT-diff visualization from `CTRLTrainDataset.generate_poisoned_data` and minor refactors/formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61347cafa0cf843a287076e60345c7431cee3240. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->