### PR TITLE
chore: align model utils and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ This library currently supports the following poisoning attack algorithms agains
 
 | Aliase       | Paper                                                                                                                                                              | Conference | Config |
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
-| SSLBKD          | [Backdoor attacks on self-supervised learning](https://doi.org/10.1109/CVPR52688.2022.01298)                                                                              | CVPR 2022  | [config](configs/poisoning/poisoning_based/sslbkd.yaml) |
+| SSL-Backdoor          | [Backdoor attacks on self-supervised learning](https://doi.org/10.1109/CVPR52688.2022.01298)                                                                              | CVPR 2022  | [train config](configs/poisoning/sslbkd.yaml) [test config](configs/poisoning/sslbkd_test.yaml) |
+| BadEncoder | [BadEncoder: Backdoor Attacks to Pre-trained Encoders in Self-Supervised Learning](https://ieeexplore.ieee.org/abstract/document/9833644/) | S&P 2022| [config](configs/attacks/badencoder.py) [train config](configs/attacks/badencoder_train.yaml) [test config](configs/attacks/badencoder_test.yaml)|
 | CTRL            | [An Embarrassingly Simple Backdoor Attack on Self-supervised Learning](https://openaccess.thecvf.com/content/ICCV2023/html/Li_An_Embarrassingly_Simple_Backdoor_Attack_on_Self-supervised_Learning_ICCV_2023_paper.html) | ICCV 2023  |  |
-| CorruptEncoder  | [Data poisoning based backdoor attacks to contrastive learning](https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_Data_Poisoning_based_Backdoor_Attacks_to_Contrastive_Learning_CVPR_2024_paper.html)       | CVPR 2024  |  |
+| CorruptEncoder  | [Data poisoning based backdoor attacks to contrastive learning](https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_Data_Poisoning_based_Backdoor_Attacks_to_Contrastive_Learning_CVPR_2024_paper.html)       | CVPR 2024  | [train config](configs/poisoning/corruptencoder_imagenet100.yaml) |
 | BLTO (inference)| [BACKDOOR CONTRASTIVE LEARNING VIA BI-LEVEL TRIGGER OPTIMIZATION](https://openreview.net/forum?id=oxjeePpgSP)                                                              | ICLR 2024  |  |
-| BadEncoder | [BadEncoder: Backdoor Attacks to Pre-trained Encoders in Self-Supervised Learning](https://ieeexplore.ieee.org/abstract/document/9833644/) | S&P 2022| [config](configs/attacks/badencoder.py) |
-| DRUPE | [Distribution Preserving Backdoor Attack in Self-supervised Learning](https://www.computer.org/csdl/proceedings-article/sp/2024/313000a029/1RjEa5rjsHK) | S&P 2024 | [config](configs/attacks/drupe.py), [train](configs/attacks/drupe_train.yaml), [test](configs/attacks/drupe_test.yaml) |
+| DRUPE | [Distribution Preserving Backdoor Attack in Self-supervised Learning](https://www.computer.org/csdl/proceedings-article/sp/2024/313000a029/1RjEa5rjsHK) | S&P 2024 | [config](configs/attacks/drupe.py), [train config](configs/attacks/drupe_train.yaml), [test config](configs/attacks/badencoder_test.yaml) |
 
 ## Supported Defenses
 
@@ -56,8 +56,9 @@ We are actively developing and integrating defense mechanisms. Currently, the fo
 | Aliase        | Paper                                                                                                      | Conference                         |    Config      |
 |------------------|------------------------------------------------------------------------------------------------------------------|---------------------------------------|----------------|
 | PatchSearch    | [Defending Against Patch-Based Backdoor Attacks on Self-Supervised Learning](https://openaccess.thecvf.com/content/CVPR2023/html/Tejankar_Defending_Against_Patch-Based_Backdoor_Attacks_on_Self-Supervised_Learning_CVPR_2023_paper.html)                                       | CVPR2023 |   [doc](./docs/zh_cn/patchsearch.md), [config](configs/defense/patchsearch.py)     |
-| DEDE | [DeDe: Detecting Backdoor Samples for SSL Encoders via Decoders](http://arxiv.org/abs/2411.16154) | CVPR2025 |   [config](configs/defense/dede.py)     |
 | SSL-Cleanse | [SSL-Cleanse: Trojan detection and mitigation in self-supervised learning](https://link.springer.com/chapter/10.1007/978-3-031-73021-4_24) | ECCV2024 |   [config](configs/defense/ssl_cleanse.py)     |
+| DEDE | [DeDe: Detecting Backdoor Samples for SSL Encoders via Decoders](http://arxiv.org/abs/2411.16154) | CVPR2025 |     |
+
 
 ## Setup
 

--- a/configs/poisoning/sslbkd_shadow_copy.yaml
+++ b/configs/poisoning/sslbkd_shadow_copy.yaml
@@ -1,4 +1,0 @@
-image_size: 224
-shadow_dataset: imagenet100
-shadow_file: data/ImageNet-100/trainset.txt
-memory_file: data/ImageNet-100/trainset.txt

--- a/ssl_backdoor/constants.py
+++ b/ssl_backdoor/constants.py
@@ -1,0 +1,2 @@
+HUGGINGFACE_MODEL_PATH = "/workspace/pretrained_models"
+DATASET_THAT_NEED_TO_TRANSFORM_ENCODER = ['cifar10', 'cifar100', 'gtsrb']

--- a/ssl_backdoor/utils/model_utils.py
+++ b/ssl_backdoor/utils/model_utils.py
@@ -1,98 +1,123 @@
 from tqdm import tqdm
-
+import warnings
 import torch
 import torch.nn as nn
 import torchvision.models as models
-# import ssl_backdoor.ssl_trainers.models_vit as models_vit
-from typing import Dict, Any
-from ssl_backdoor.utils.utils import interpolate_pos_embed, get_channels
+
+from typing import Dict, Any, Tuple, Optional
+from pathlib import Path
 
 from transformers import CLIPProcessor, CLIPModel, AutoImageProcessor, AutoModel, AutoProcessor
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+
+from ssl_backdoor.constants import HUGGINGFACE_MODEL_PATH
 
 
+def _strip_prefixes(key: str, prefixes: Tuple[str, ...]) -> str:
+    """仅在前缀位置 strip，避免误删中间子串。"""
+    changed = True
+    while changed:
+        changed = False
+        for p in prefixes:
+            if key.startswith(p):
+                key = key[len(p):]
+                changed = True
+    return key
+
+
+def _transform_encoder_for_small_dataset(model: nn.Module) -> nn.Module:
+    """
+    针对小分辨率数据集（如 CIFAR）的 ResNet 常见结构改造：
+    - 去掉 maxpool
+    - 将首层 conv1 改为 3x3, stride=1
+
+    注意：如果模型不具备对应属性（非 ResNet 或结构不同），则保持原样返回。
+    """
+    if not hasattr(model, "maxpool") or not hasattr(model, "conv1"):
+        return model
+
+    model.maxpool = nn.Identity()
+    model.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+
+    return model
+
+def transform_encoder_for_small_dataset(model: nn.Module, dataset: Optional[str] = None) -> nn.Module:
+    """
+    兼容旧代码的对外接口：根据 dataset 判断是否需要对 encoder 进行小数据集适配。
+    """
+    if dataset is None:
+        return model
+    from ssl_backdoor.constants import DATASET_THAT_NEED_TO_TRANSFORM_ENCODER
+    if dataset in DATASET_THAT_NEED_TO_TRANSFORM_ENCODER:
+        _transform_encoder_for_small_dataset(model)
+    return model
+
+
+
+def remove_task_head_for_encoder(model: nn.Module):
+    for attr in ('fc', 'head', 'classifier', 'heads'):
+        if hasattr(model, attr):
+            setattr(model, attr, nn.Identity())
+            return model
+    raise ValueError(f"model 没有 fc、head、classifier 或 heads 属性")
+
+    
+# load model weights to cpu
 def load_checkpoint(wts_path: str) -> Dict[str, Any]:
     """加载并处理模型权重文件。"""
     checkpoint = torch.load(wts_path, map_location='cpu')
-    if 'model' in checkpoint:
-        return checkpoint['model']
-    elif 'state_dict' in checkpoint:
-        return checkpoint['state_dict']
-    elif 'model_state_dict' in checkpoint:
-        return checkpoint['model_state_dict']
-    else:
-        raise ValueError(f'No model or state_dict found in {wts_path}.')
+    for key in ['model', 'state_dict', 'model_state_dict']:
+        if key in checkpoint:
+            return checkpoint[key]
+    raise ValueError(f'No model or state_dict found in {wts_path}.')
 
 
-def get_backbone_model(arch, wts_path, device='cpu', dataset='imagenet100', freeze_backbone=True):
+def get_backbone_model(arch, wts_path, device='cpu', dataset='imagenet100', freeze_backbone=False):
     """获取并加载预训练的主干网络。"""
-    if 'vit' in arch:
-        # model = models_vit.__dict__[arch](num_classes=100, global_pool=True)
-        # checkpoint_model = load_model_weights(model, wts_path)
-        
-        # # 移除头部
-        # for k in ['head.weight', 'head.bias']:
-        #     if k in checkpoint_model and checkpoint_model[k].shape != model.state_dict()[k].shape:
-        #         print(f"移除预训练检查点中的键 {k}")
-        #         del checkpoint_model[k]
 
-        # # 插值位置嵌入
-        # interpolate_pos_embed(model, checkpoint_model)
-        # model.load_state_dict(checkpoint_model, strict=False)
-        pass
+    model = models.__dict__[arch]()
+    model = remove_task_head_for_encoder(model)
+    from ssl_backdoor.constants import DATASET_THAT_NEED_TO_TRANSFORM_ENCODER
+    if dataset in DATASET_THAT_NEED_TO_TRANSFORM_ENCODER and 'resnet' in arch.lower():
+        _transform_encoder_for_small_dataset(model)
 
-    else:
+    if wts_path is None:
+        warnings.warn("wts_path is None, return init model", UserWarning)
+        return model
         
-        if arch != 'SqueezeNet':
-            model = models.__dict__[arch]()
-            model = remove_task_head_for_encoder(model)
-            model = transform_encoder_for_small_dataset(model, dataset)
-        else:
-            model = models.__dict__[arch](num_classes=2048)
 
-        if wts_path is None:
-            print(f"wts_path is None, return init model")
-            return model
-        
-        state_dict = load_checkpoint(wts_path)
-        print(f"state_dict keys: {state_dict.keys()}")
-        def is_valid_model_param_key(key):
-            valid_keys = ['encoder_q', 'backbone', 'encoder', 'model']
-            invalid_keys = ['fc', 'head', 'predictor', 'projector', 'projection', 
-                          'encoder_k', 'model_t', 'momentum']
-                
-            # 如果键包含任何无效关键词，过滤掉
-            if any([k in key for k in invalid_keys]):
-                return False
+    state_dict = load_checkpoint(wts_path)
+    print(f"state_dict keys: {state_dict.keys()}")
+    def is_valid_model_param_key(key):
+        key = _strip_prefixes(key, ('module.', 'model.'))
+        valid_keys = ['encoder_q', 'backbone', 'encoder', 'model']
+        invalid_keys = ['fc', 'head', 'predictor', 'projector', 'projection', 
+                        'encoder_k', 'model_t', 'momentum', 'regressor']
             
-            # 如果键包含任何有效关键词，保留它
-            if any([k in key for k in valid_keys]):
-                return True
-            
-            # 如果键既不包含有效关键词也不包含无效关键词，可能是直接的层名
-            # 检查是否是常见的网络层命名
-            common_layer_patterns = ['conv', 'bn', 'layer', 'downsample', 'running_']
-            if any([pattern in key for pattern in common_layer_patterns]):
-                return True
-            
+        # 如果键包含任何无效关键词，过滤掉
+        if any([k in key for k in invalid_keys]):
             return False
         
-        def model_param_key_filter(key):
-            if 'model.' in key:
-                key = key.replace('model.', '')
-            if 'module.' in key:
-                key = key.replace('module.', '')
-            if 'encoder.' in key:
-                key = key.replace('encoder.', '')
-            if 'encoder_q.' in key:
-                key = key.replace('encoder_q.', '')
-            if 'backbone.' in key:
-                key = key.replace('backbone.', '')
-            return key
+        # 如果键包含任何有效关键词，保留它
+        if any([k in key for k in valid_keys]):
+            return True
         
-        state_dict = {model_param_key_filter(k): v for k, v in state_dict.items() if is_valid_model_param_key(k)}
+        # 如果键既不包含有效关键词也不包含无效关键词，可能是直接的层名
+        # 检查是否是常见的网络层命名
+        common_layer_patterns = ['conv', 'bn', 'layer', 'downsample', 'running_']
+        if any([pattern in key for pattern in common_layer_patterns]):
+            return True
+        
+        return False
+    
+    
+    state_dict = {_strip_prefixes(k, ('module.', 'model.', 'encoder_q.', 'encoder.', 'backbone.')): v for k, v in state_dict.items() if is_valid_model_param_key(k)}
 
-        msg = model.load_state_dict(state_dict, strict=True)
-        print(f"msg: {msg}")
+    incompatible = model.load_state_dict(state_dict, strict=False)
+    if getattr(incompatible, "unexpected_keys", None):
+        print(f"[get_backbone_model] unexpected_keys({len(incompatible.unexpected_keys)}): {incompatible.unexpected_keys}")
+    if getattr(incompatible, "missing_keys", None):
+        raise RuntimeError(f"[get_backbone_model] missing_keys({len(incompatible.missing_keys)}): {incompatible.missing_keys}")
         
     model = model.to(device)
     if freeze_backbone:
@@ -102,75 +127,104 @@ def get_backbone_model(arch, wts_path, device='cpu', dataset='imagenet100', free
     return model
 
 
-def load_huggingface_model(model_name, model_path):
+def load_huggingface_representation_model(model_name, device='cpu'):
     """
     根据模型名称加载对应的参考模型和处理器
     
     Args:
         model_name (str): 模型名称，例如'clip'或'dinov2-base'
-        device (torch.device): 模型运行的设备
+        device (str or torch.device): 模型运行的设备
         
     Returns:
         tuple: (model, processor)
     """
 
-    MODEL_PATH = "/workspace/pretrained_models"
-    if model_name.lower() == 'clip':
-        model = CLIPModel.from_pretrained(f"{MODEL_PATH}/clip-vit-base-patch32")
-        processor = CLIPProcessor.from_pretrained(f"{MODEL_PATH}/clip-vit-base-patch32")
-    elif model_name.lower() == 'siglip':
-        model = AutoModel.from_pretrained(f"{MODEL_PATH}/siglip-base-patch16-224/model")
-        processor = AutoProcessor.from_pretrained(f"{MODEL_PATH}/siglip-base-patch16-224/processor")
+    if 'clip' in model_name.lower():
+        model = CLIPModel.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}")
+        processor = CLIPProcessor.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}")
+    elif 'siglip' in model_name.lower():
+        model = AutoModel.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}/model")
+        processor = AutoProcessor.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}/processor")
     else:
         # 对于其他huggingface模型，尝试自动加载
-        model = AutoModel.from_pretrained(model_name)
-        processor = AutoImageProcessor.from_pretrained(model_name)
+        model = AutoModel.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}")
+        processor = AutoImageProcessor.from_pretrained(f"{HUGGINGFACE_MODEL_PATH}/{model_name}")
     
     model.eval()
+    model = model.to(device)
     return model, processor
 
 
-def load_model(model_type: str, model_path: str, dataset='cifar10') -> nn.Module:
+def load_model(model_type: str, model_name: str, model_path: str, dataset: str = 'cifar10', device: str = 'cpu') -> Tuple[nn.Module, Optional[Any]]:
     """
-    加载后门模型
-    
+    加载模型（支持 pytorch 与 huggingface）。
+
     Args:
-        model_type (str): 模型类型，如 'resnet18'
-        model_path (str): 模型权重路径
-        dataset (str): 数据集名称
-        
-    Returns:
-        nn.Module: 加载的模型
-    """
-    processor = None
-    model_type = model_type.lower()
-    DEVICE = 'cpu'
-    HUGGINFACE_MODEL_LIST = ['clip', 'siglip']
-    
-    if any([model in model_type for model in HUGGINFACE_MODEL_LIST]):
-        model, processor = load_huggingface_model(model_type, model_path)
+        model_type (str): 模型来源类型，取值为 'pytorch' 或 'huggingface'（兼容常见拼写变体）。
+        model_name (str): 模型名称。
+        model_path (str): 训练好的模型权重路径。
+        dataset (str): 数据集名称，用于 pytorch 模型的结构适配。
+        device (str): 模型加载到的设备。
 
+    Returns:
+        tuple[nn.Module, Any | None]: (模型, 处理器)。pytorch 返回 (model, None)，huggingface 返回 (model, processor)。
+    """
+    processor: Optional[Any] = None
+
+    normalized_type = model_type.strip().lower()
+    huggingface_alias = {'huggingface', 'hf', 'hugginface', 'hugggingface'}
+    pytorch_alias = {'pytorch', 'torch'}
+
+    if normalized_type in huggingface_alias:
+        # 1) 先从本地 MODEL_PATH 下加载同名模型与处理器
+        model, processor = load_huggingface_representation_model(model_name, device=device)
+
+        # 2) 再加载训练好的权重
         state_dict = load_checkpoint(model_path)
-        state_dict = {k.replace('module.', ''): v for k, v in state_dict.items()}
-        msg = model.load_state_dict(state_dict, strict=True)
-        print(f"load model msg: {msg}")
+        state_dict = {_strip_prefixes(k, ('module.', 'model.')): v for k, v in state_dict.items()}
+
+        # 3) 兼容不同工程保存的 CLIP 命名，将其映射到 HuggingFace 的键名
+        def _map_clip_keys_to_hf(sd: Dict[str, Any]) -> Dict[str, Any]:
+            mapped = {}
+            for k, v in sd.items():
+                new_k = k
+                # vision branch
+                new_k = new_k.replace('vision_embeddings', 'vision_model.embeddings')
+                new_k = new_k.replace('vision_encoder', 'vision_model.encoder')
+                new_k = new_k.replace('vision_pre_layernorm', 'vision_model.pre_layernorm')
+                new_k = new_k.replace('vision_post_layernorm', 'vision_model.post_layernorm')
+                # text branch
+                new_k = new_k.replace('text_embeddings', 'text_model.embeddings')
+                new_k = new_k.replace('text_encoder', 'text_model.encoder')
+                new_k = new_k.replace('text_final_layer_norm', 'text_model.final_layer_norm')
+                mapped[new_k] = v
+            return mapped
+
+        state_dict = _map_clip_keys_to_hf(state_dict)
+        incompatible = model.load_state_dict(state_dict, strict=False)
+        if getattr(incompatible, "unexpected_keys", None):
+            print(f"[load_model] unexpected_keys({len(incompatible.unexpected_keys)}): {incompatible.unexpected_keys}")
+        if getattr(incompatible, "missing_keys", None):
+            raise RuntimeError(f"[load_model] missing_keys({len(incompatible.missing_keys)}): {incompatible.missing_keys}")
+    elif normalized_type in pytorch_alias:
+        # 直接通过 backbone 加载（内部已处理是否去除任务头、微调小数据集等）
+        model = get_backbone_model(model_name, model_path, device=device, dataset=dataset, freeze_backbone=False)
     else:
-        print(f"加载标准模型: {model_type}")
-        # has been loaded in get_backbone_model
-        model = get_backbone_model(model_type, model_path, device=DEVICE, dataset=dataset, freeze_backbone=True)
-    
+        raise ValueError(f"未知的 model_type: {model_type}. 期望 'pytorch' 或 'huggingface'")
+
     model.eval()
+    model = model.to(device)
     return model, processor
 
 
-def get_features(model, dataloader, device, processor=None, normalize=True):
+def get_features(model, dataloader, device, processor=None, normalize=False):
     """从模型中提取特征"""
     features = []
     paths = []
     labels = []
     
     model.eval()
-    with torch.no_grad():
+    with torch.inference_mode():
         for batch in tqdm(dataloader, desc="Extracting features"):
             if processor is not None:  # 使用处理器的模型（CLIP, DINOv2等）
                 images, targets, img_paths = batch
@@ -221,33 +275,3 @@ def get_features(model, dataloader, device, processor=None, normalize=True):
     return features, paths, labels 
 
 
-def transform_encoder_for_small_dataset(model: nn.Module, dataset: str):
-    assert dataset in ['cifar10', 'cifar100', 'imagenet100', 'imagenet-1k', 'imagenet', 'stl10', 'gtsrb']
-
-    # 判断是不是resnet
-    if not 'resnet' in model.__class__.__name__.lower():
-        print(f"encoder 不是resnet，不进行适应小数据集的转换")
-        return model
-    
-    if 'cifar10' in dataset or 'cifar100' in dataset or 'gtsrb' in dataset:
-        model.maxpool = nn.Identity()
-    if 'imagenet' not in dataset:
-        print(f"transform_encoder_for_small_dataset: {dataset}")
-        model.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
-
-    return model
-
-
-def remove_task_head_for_encoder(model: nn.Module):
-    if hasattr(model, 'fc'):
-        model.fc = nn.Identity()
-    elif hasattr(model, 'head'):
-        model.head = nn.Identity()
-    elif hasattr(model, 'classifier'):
-        model.classifier = nn.Identity()
-    elif hasattr(model, 'heads'):
-        model.heads = nn.Identity()
-    else:
-        raise ValueError(f"model 没有fc或head或classifier属性")
-    
-    return model

--- a/tools/run_badencoder.py
+++ b/tools/run_badencoder.py
@@ -129,8 +129,9 @@ def main():
     #     else:
     #         raise NotImplementedError(f"未支持的编码器使用信息: {config['encoder_usage_info']}")
     from ssl_backdoor.utils.model_utils import load_model
-    clean_model, processor = load_model(config['arch'], config['pretrained_encoder'], dataset=config['encoder_usage_info'])
-    clean_model = clean_model.cuda()
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    clean_model, processor = load_model('pytorch', config['arch'], config['pretrained_encoder'], dataset=config['encoder_usage_info'], device=device)
+    # clean_model = clean_model.cuda()
     clean_model.eval()
 
     for p in clean_model.parameters():

--- a/tools/run_dede.py
+++ b/tools/run_dede.py
@@ -126,7 +126,10 @@ def main():
 
     # 5. 加载可疑模型
     from ssl_backdoor.utils.model_utils import load_model
-    suspicious_model, processor = load_model(config.arch, config.weights_path, dataset=config.dataset_name)
+    _arch_lower = str(config.arch).lower()
+    _model_type = 'huggingface' if ('clip' in _arch_lower or 'siglip' in _arch_lower) else 'pytorch'
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    suspicious_model, processor = load_model(_model_type, config.arch, config.weights_path, dataset=config.dataset_name, device=device)
     suspicious_model.eval()
 
     from transformers.modeling_outputs import BaseModelOutputWithPooling

--- a/tools/run_drupe.py
+++ b/tools/run_drupe.py
@@ -129,8 +129,11 @@ def main():
     #         raise
 
     # === 新实现: 统一加载预训练模型（参考 run_dede.py） ===
-    clean_model, _ = load_model(config_obj.arch, config_obj.pretrained_encoder, dataset=config_obj.encoder_usage_info)
-    clean_model = clean_model.cuda()
+    _arch_lower = str(config_obj.arch).lower()
+    _model_type = 'huggingface' if ('clip' in _arch_lower or 'siglip' in _arch_lower) else 'pytorch'
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    clean_model, _ = load_model(_model_type, config_obj.arch, config_obj.pretrained_encoder, dataset=config_obj.encoder_usage_info, device=device)
+    # clean_model = clean_model.cuda()
     clean_model.eval()
     
     # 6. 运行DRUPE攻击


### PR DESCRIPTION
## Summary
- Align `model_utils` algorithm aliases and config links; improve model loading utilities.
- Add constants for common model/dataset paths.
- Remove unused `sslbkd_shadow_copy.yaml` and adjust docs/scripts accordingly.

## Test plan
- [ ] Import `ssl_backdoor.utils.model_utils` and run a minimal model load path.
- [ ] Run a dry-run of tooling entrypoints (`tools/run_*.py`) to ensure CLI parsing still works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies model loading across PyTorch and HuggingFace with device-aware utilities, adds shared constants, updates CLI tools to the new API, and refreshes README attack/defense entries and config links.
> 
> - **Core utilities (`ssl_backdoor/utils/model_utils.py`)**:
>   - Add `load_model(model_type, model_name, ...)` to load PyTorch or HuggingFace encoders with device control; maps CLIP keys and normalizes state_dict prefixes.
>   - Introduce `_strip_prefixes`, small-dataset encoder transforms, and `remove_task_head_for_encoder` improvements.
>   - Rework `get_backbone_model` (simpler construction, stricter/clearer state_dict filtering; default `freeze_backbone=False`).
>   - Add `load_huggingface_representation_model` using `HUGGINGFACE_MODEL_PATH`; update `get_features` to use `inference_mode` and optional normalization.
> - **Constants (`ssl_backdoor/constants.py`)**:
>   - Add `HUGGINGFACE_MODEL_PATH` and `DATASET_THAT_NEED_TO_TRANSFORM_ENCODER`.
> - **Tools**:
>   - Update `tools/run_badencoder.py`, `tools/run_dede.py`, `tools/run_drupe.py` to use new `load_model` API and auto-select `cuda`/`cpu`.
> - **Docs (`README.md`)**:
>   - Tidy supported attacks/defenses table: rename to `SSL-Backdoor`, add/update config links for `BadEncoder`, `CorruptEncoder`, `DRUPE`, and adjust `DEDE` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5199f86082d7adb4e6568c3ace15c0e920f8b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->