### PR TITLE
feat(patchsearch): enhance detection metrics and model evaluation

### DIFF
--- a/ssl_backdoor/defenses/patchsearch/__init__.py
+++ b/ssl_backdoor/defenses/patchsearch/__init__.py
@@ -38,8 +38,7 @@ def run_patchsearch(
     batch_size=64,
     num_workers=8,
     topk_thresholds=None,
-    experiment_id='defense_run',
-    external_test_loader=None
+    experiment_id='defense_run'
 ):
     """
     运行PatchSearch防御方法

--- a/ssl_backdoor/defenses/patchsearch/__init__.py
+++ b/ssl_backdoor/defenses/patchsearch/__init__.py
@@ -6,6 +6,7 @@ PatchSearch是一种用于检测自监督学习模型中后门的防御方法，
 
 import os
 import numpy as np
+from sklearn.metrics import roc_auc_score
 
 import torch
 
@@ -36,11 +37,9 @@ def run_patchsearch(
     prune_clusters=True,
     batch_size=64,
     num_workers=8,
-    use_cached_feats=True,
-    use_cached_poison_scores=True,
     topk_thresholds=None,
     experiment_id='defense_run',
-    fast_clustering=False
+    external_test_loader=None
 ):
     """
     运行PatchSearch防御方法
@@ -63,11 +62,8 @@ def run_patchsearch(
         prune_clusters: 是否剪枝聚类
         batch_size: 批处理大小
         num_workers: 工作进程数量
-        use_cached_feats: 是否使用缓存的特征
-        use_cached_poison_scores: 是否使用缓存的毒性分数
         topk_thresholds: top-k阈值列表
         experiment_id: 实验ID，用于创建输出目录
-        fast_clustering: 是否使用快速聚类方法替代FAISS聚类, 默认关闭, 仅用于调试
         
     返回:
         result_dict: 包含检测结果的字典，具有以下键:
@@ -92,7 +88,7 @@ def run_patchsearch(
     if model is None:
         print(f"从权重加载模型: {weights_path}")
 
-        model = get_backbone_model(arch, weights_path)
+        model = get_backbone_model(arch, weights_path, device='cpu', dataset=dataset_name, freeze_backbone=True)
         model.eval()
     else:
         model.eval()
@@ -132,20 +128,9 @@ def run_patchsearch(
         remove_per_iteration=remove_per_iteration,
         batch_size=batch_size,
         num_workers=num_workers,
-        use_cached_feats=use_cached_feats,
-        use_cached_poison_scores=use_cached_poison_scores,
         prune_clusters=prune_clusters,
-        topk_thresholds=topk_thresholds,
-        fast_clustering=fast_clustering
+        topk_thresholds=topk_thresholds
     )
-    
-    # 如果是第一次运行且缓存了特征，可能会返回None
-    if poison_scores is None:
-        print("特征已缓存，请再次运行以使用缓存的特征进行检测")
-        return {
-            "status": "CACHED_FEATURES",
-            "output_dir": experiment_dir
-        }
     
     # 计算topk准确率
     if topk_thresholds is None:
@@ -157,18 +142,26 @@ def run_patchsearch(
             continue
         topk_accuracy[k] = is_poison[sorted_inds[:k]].sum() * 100.0 / k
     
+    # Calculate AUROC
+    try:
+        auroc = roc_auc_score(is_poison, poison_scores)
+    except ValueError:
+        auroc = 0.0
+    
     # 保存结果
     result_dict = {
         "poison_scores": poison_scores,
         "sorted_indices": sorted_inds,
         "is_poison": is_poison,
         "topk_accuracy": topk_accuracy,
+        "auroc": auroc,
         "output_dir": experiment_dir
     }
     
     # 打印结果
     print("\n检测结果:")
     print(f"结果保存在: {experiment_dir}")
+    print(f"AUROC: {auroc*100:.2f}%")
     print("在不同k值下的检测准确率:")
     for k, acc in topk_accuracy.items():
         print(f"Top-{k}: {acc:.2f}%")
@@ -197,7 +190,8 @@ def run_patchsearch_filter(
     weight_decay=1e-4,
     print_freq=10,
     eval_freq=50,
-    seed=42
+    seed=42,
+    external_test_loader=None
 ):
     """
     运行PatchSearch的第二阶段：训练一个分类器来过滤可能的后门样本
@@ -261,7 +255,8 @@ def run_patchsearch_filter(
         weight_decay=weight_decay,
         print_freq=print_freq,
         eval_freq=eval_freq,
-        seed=seed
+        seed=seed,
+        external_test_loader=external_test_loader
     )
     
     print(f"过滤后的数据集已保存到: {filtered_file_path}")

--- a/ssl_backdoor/defenses/patchsearch/core.py
+++ b/ssl_backdoor/defenses/patchsearch/core.py
@@ -289,8 +289,8 @@ def patchsearch_iterative(
             if prune_clusters:
                 # 移除一些最不有毒的簇
                 rem = int(remove_per_iteration * len(candidate_clusters))
-                candidate_clusters = cluster_scores[:-rem, 0].tolist()
-            
+                candidate_clusters = cluster_scores[:len(cluster_scores)-rem, 0].tolist()
+                
             cur_iter += 1
     
     # 保存或加载有毒得分

--- a/ssl_backdoor/defenses/patchsearch/core.py
+++ b/ssl_backdoor/defenses/patchsearch/core.py
@@ -12,12 +12,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import pairwise_distances, roc_auc_score
 
 from .utils import (
     get_model, get_feats, faiss_kmeans, KMeansLinear, get_candidate_patches,
     run_gradcam, extract_max_window, save_patches, paste_patch
 )
+from ssl_backdoor.utils.utils import set_seed
+
 
 
 def setup_logger(save_dir):
@@ -68,11 +70,8 @@ def patchsearch_iterative(
     remove_per_iteration=0.25,
     batch_size=64,
     num_workers=8,
-    use_cached_feats=True,
-    use_cached_poison_scores=True,
     prune_clusters=True,
-    topk_thresholds=None,
-    fast_clustering=False
+    topk_thresholds=None
 ):
     """
     PatchSearch的迭代搜索实现
@@ -91,11 +90,8 @@ def patchsearch_iterative(
         remove_per_iteration: 每次迭代移除的聚类比例
         batch_size: 批处理大小
         num_workers: 工作进程数量
-        use_cached_feats: 是否使用缓存的特征
-        use_cached_poison_scores: 是否使用缓存的毒性分数
         prune_clusters: 是否剪枝聚类
         topk_thresholds: top-k阈值列表
-        fast_clustering: 是否使用快速聚类方法替代FAISS聚类, 默认关闭
         
     返回:
         poison_scores: 毒性得分
@@ -121,14 +117,13 @@ def patchsearch_iterative(
     logger.info(f"每次迭代的样本数量: {samples_per_iteration}")
     logger.info(f"每次迭代移除的聚类比例: {remove_per_iteration}")
     logger.info(f"是否剪枝聚类: {prune_clusters}")
-    logger.info(f"是否使用快速聚类: {fast_clustering}")
     
     # 缓存文件路径
     cache_file_path = os.path.join(save_dir, 'cached_feats.pth')
     poison_scores_file = os.path.join(save_dir, 'poison-scores.npy')
     
     # 加载或提取特征
-    if os.path.exists(cache_file_path) and use_cached_feats:
+    if os.path.exists(cache_file_path):
         logger.info(f"从缓存加载特征: {cache_file_path}")
         train_val_feats, train_val_labels, train_val_is_poisoned, train_val_inds = torch.load(cache_file_path)
     else:
@@ -136,48 +131,17 @@ def patchsearch_iterative(
         train_val_feats, train_val_labels, train_val_is_poisoned, train_val_inds = get_feats(model, train_val_loader)
         logger.info(f"保存特征到缓存: {cache_file_path}")
         torch.save((train_val_feats, train_val_labels, train_val_is_poisoned, train_val_inds), cache_file_path)
-        if use_cached_feats:
-            logger.info("特征已缓存，退出")
-            return None, None, None
     
-    # 执行聚类 - 使用快速聚类方法替代FAISS聚类
+    # 只有在有毒分数已保存的情况下才使用缓存
+    scores_cached = os.path.exists(poison_scores_file)
+    
+    # 如果已经有分数缓存，我们可以直接跳过聚类和搜索步骤（除非我们需要中间结果如聚类中心等，但在当前代码结构中，主要输出是poison_scores）
+    # 但为了保持代码结构的连贯性（比如后续可能用到聚类结果），我们还是先加载分数，如果是缓存的，就跳过循环
+    
+    # 执行聚类 - 使用原始的FAISS聚类方法（CPU模式）
     logger.info(f"执行聚类，簇数量: {num_clusters}")
-    
-    if fast_clustering:
-        # 快速聚类方法：随机选择聚类中心并分配样本到最近中心
-        logger.info("使用快速聚类方法...")
-        train_val_feats_np = train_val_feats.numpy()
-        n_samples = train_val_feats_np.shape[0]
-        
-        # 随机选择num_clusters个样本作为初始聚类中心
-        np.random.seed(42)  # 设置随机种子以确保可重复性
-        random_indices = np.random.choice(n_samples, num_clusters, replace=False)
-        centroids = train_val_feats_np[random_indices]
-        
-        # 计算每个样本到每个聚类中心的距离
-        distances = pairwise_distances(train_val_feats_np, centroids, metric='euclidean')
-        
-        # 将每个样本分配给最近的聚类中心
-        train_a = np.argmin(distances, axis=1).reshape(-1, 1)
-        train_d = np.min(distances, axis=1).reshape(-1, 1)
-        
-        # 创建一个简单的索引对象，实现search方法
-        class SimpleIndex:
-            def __init__(self, centroids):
-                self.centroids = centroids
-                
-            def search(self, feats, k=1):
-                distances = pairwise_distances(feats, self.centroids, metric='euclidean')
-                indices = np.argmin(distances, axis=1).reshape(-1, k)
-                min_distances = np.min(distances, axis=1).reshape(-1, k)
-                return min_distances, indices
-        
-        index = SimpleIndex(centroids)
-        logger.info("快速聚类完成")
-    else:
-        # 使用原始的FAISS聚类方法
-        logger.info("使用K-means执行聚类...")
-        train_d, train_a, index, centroids = faiss_kmeans(train_val_feats, num_clusters)
+    logger.info("使用K-means执行聚类...")
+    train_d, train_a, index, centroids = faiss_kmeans(train_val_feats, num_clusters)
     
     # 预处理数据
     train_val_dataset = train_val_loader.dataset
@@ -242,87 +206,95 @@ def patchsearch_iterative(
     cur_iter = 0
     
     # 只有在有毒分数已保存的情况下才使用缓存
-    use_cached_poison_scores = use_cached_poison_scores and os.path.exists(poison_scores_file)
+    use_cached_poison_scores = os.path.exists(poison_scores_file)
     processed_count = 0
     
-    # 如果不使用缓存的有毒分数，则运行无限循环
-    while not use_cached_poison_scores:
-        logger.info(f"迭代: {cur_iter}")
-        
-        # 从每个候选聚类中采样候选图像
-        candidate_poison_i = []
-        for clust_id in candidate_clusters:
-            clust_i = random_cluster_wise_i[clust_id]
-            for _ in range(min(len(clust_i), samples_per_iteration)):
-                candidate_poison_i.append(clust_i.pop(0))
-        
-        # 如果没有找到候选图像则退出
-        if not len(candidate_poison_i):
-            logger.info("未找到更多候选图像，退出循环")
-            break
-        
-        # 创建候选有毒图像的数据加载器
-        candidate_poison_dataset = Subset(
-            train_val_dataset, torch.tensor(candidate_poison_i)
-        )
-        candidate_poison_loader = DataLoader(
-            candidate_poison_dataset,
-            shuffle=False, batch_size=batch_size,
-            num_workers=num_workers, pin_memory=True
-        )
-        processed_count += len(candidate_poison_dataset)
-        
-        # 提取候选补丁
-        logger.info("提取补丁")
-        candidate_patches = get_candidate_patches(
-            model_with_kmeans, candidate_poison_loader, arch, window_w, repeat_patch
-        )
-        
-        # 计算每个候选补丁的有毒得分
-        logger.info("评估补丁")
-        for candidate_patch, patch_idx in tqdm(zip(candidate_patches, candidate_poison_i)):
-            cur_scores = []
-            # 一个图像可以有多个补丁
-            for cur_patch in candidate_patch:
-                with torch.no_grad():
-                    # 将候选补丁粘贴到测试图像上并提取特征
-                    poisoned_test_images = paste_patch(test_images.clone(), cur_patch)
-                    feats_poisoned_test_images = backbone(poisoned_test_images.cuda()).cpu().numpy()
-                    # 计算翻转并更新有毒得分
-                    _, poisoned_test_images_a = index.search(feats_poisoned_test_images, 1)
-                    new = np.count_nonzero(poisoned_test_images_a == train_a[patch_idx, 0])
-                    orig = np.count_nonzero(test_images_a == train_a[patch_idx, 0])
-                    cur_scores.append(new - orig)
-            # 取图像中所有补丁的最大翻转
-            assert poison_scores[patch_idx] == 0
-            poison_scores[patch_idx] += max(cur_scores)
-        
-        # 计算每个候选簇的得分
-        logger.info(f"最大有毒得分 {poison_scores.argmax()} : {poison_scores.max()}")
-        cluster_scores = []
-        for clust_id in candidate_clusters:
-            cluster_scores.append((clust_id, poison_scores[train_a[:, 0] == clust_id].max()))
-        cluster_scores = np.array(cluster_scores).astype(int)
-        cluster_scores = cluster_scores[cluster_scores[:, 1].argsort()][::-1]
-        
-        # 打印一些顶级有毒簇
-        for clust_rank, (clust_id, clust_score) in enumerate(cluster_scores.tolist()[:10]):
-            logger.info(f"顶级有毒簇: 排名 {clust_rank:3d} 簇ID {clust_id:3d} 得分 {clust_score}")
-        
-        logger.info(f"处理计数: {processed_count:6d}/{len(train_val_dataset)} ({processed_count*100/len(train_val_dataset):.1f}%)")
-        
-        if prune_clusters:
-            # 移除一些最不有毒的簇
-            rem = int(remove_per_iteration * len(candidate_clusters))
-            candidate_clusters = cluster_scores[:-rem, 0].tolist()
-        
-        cur_iter += 1
-    
-    # 保存或加载有毒得分
     if use_cached_poison_scores:
-        logger.info(f"从缓存加载有毒得分: {poison_scores_file}")
+        logger.info(f"检测到缓存的毒性分数文件: {poison_scores_file}，将跳过搜索过程")
         poison_scores = np.load(poison_scores_file)
     else:
+        # 如果不使用缓存的有毒分数，则运行无限循环
+        while True:
+            logger.info(f"迭代: {cur_iter}")
+            
+            # 从每个候选聚类中采样候选图像
+            candidate_poison_i = []
+            for clust_id in candidate_clusters:
+                clust_i = random_cluster_wise_i[clust_id]
+                for _ in range(min(len(clust_i), samples_per_iteration)):
+                    candidate_poison_i.append(clust_i.pop(0))
+            
+            # 如果没有找到候选图像则退出
+            if not len(candidate_poison_i):
+                logger.info("未找到更多候选图像，退出循环")
+                break
+            
+            # 创建候选有毒图像的数据加载器
+            candidate_poison_dataset = Subset(
+                train_val_dataset, torch.tensor(candidate_poison_i)
+            )
+            candidate_poison_loader = DataLoader(
+                candidate_poison_dataset,
+                shuffle=False, batch_size=batch_size,
+                num_workers=num_workers, pin_memory=True
+            )
+            processed_count += len(candidate_poison_dataset)
+            
+            # 提取候选补丁
+            logger.info("提取补丁")
+            candidate_patches = get_candidate_patches(
+                model_with_kmeans, candidate_poison_loader, arch, window_w, repeat_patch
+            )
+            
+            # 计算每个候选补丁的有毒得分
+            logger.info("评估补丁")
+            for candidate_patch, patch_idx in tqdm(zip(candidate_patches, candidate_poison_i)):
+                cur_scores = []
+                # 一个图像可以有多个补丁
+                for cur_patch in candidate_patch:
+                    with torch.no_grad():
+                        # 将候选补丁粘贴到测试图像上并提取特征
+                        poisoned_test_images = paste_patch(test_images.clone(), cur_patch)
+                        
+                        # 分批次处理以避免显存溢出 (OOM)
+                        feats_list = []
+                        for i in range(0, poisoned_test_images.size(0), batch_size):
+                            batch = poisoned_test_images[i:i + batch_size].cuda()
+                            feats_list.append(backbone(batch).cpu())
+                        feats_poisoned_test_images = torch.cat(feats_list).numpy()
+                        
+                        # 计算翻转并更新有毒得分
+                        _, poisoned_test_images_a = index.search(feats_poisoned_test_images, 1)
+                        new = np.count_nonzero(poisoned_test_images_a == train_a[patch_idx, 0])
+                        orig = np.count_nonzero(test_images_a == train_a[patch_idx, 0])
+                        cur_scores.append(new - orig)
+                # 取图像中所有补丁的最大翻转
+                assert poison_scores[patch_idx] == 0
+                poison_scores[patch_idx] += max(cur_scores)
+            
+            # 计算每个候选簇的得分
+            logger.info(f"最大有毒得分 {poison_scores.argmax()} : {poison_scores.max()}")
+            cluster_scores = []
+            for clust_id in candidate_clusters:
+                cluster_scores.append((clust_id, poison_scores[train_a[:, 0] == clust_id].max()))
+            cluster_scores = np.array(cluster_scores).astype(int)
+            cluster_scores = cluster_scores[cluster_scores[:, 1].argsort()][::-1]
+            
+            # 打印一些顶级有毒簇
+            for clust_rank, (clust_id, clust_score) in enumerate(cluster_scores.tolist()[:10]):
+                logger.info(f"顶级有毒簇: 排名 {clust_rank:3d} 簇ID {clust_id:3d} 得分 {clust_score}")
+            
+            logger.info(f"处理计数: {processed_count:6d}/{len(train_val_dataset)} ({processed_count*100/len(train_val_dataset):.1f}%)")
+            
+            if prune_clusters:
+                # 移除一些最不有毒的簇
+                rem = int(remove_per_iteration * len(candidate_clusters))
+                candidate_clusters = cluster_scores[:-rem, 0].tolist()
+            
+            cur_iter += 1
+    
+    # 保存或加载有毒得分
+    if not use_cached_poison_scores:
         logger.info(f"保存有毒得分到: {poison_scores_file}")
         np.save(poison_scores_file, poison_scores)
     
@@ -348,6 +320,13 @@ def patchsearch_iterative(
     
     logger.info('在顶部k个中的准确率 | ' + ' '.join(f'{k:7d}' for k in topk_thresholds))
     logger.info('在顶部k个中的准确率 | ' + ' '.join(f'{acc:7.1f}' for acc in accs))
+    
+    # 计算AUROC
+    try:
+        auroc = roc_auc_score(train_p[:, 0], poison_scores)
+        logger.info(f'AUROC: {auroc*100:.2f}%')
+    except Exception as e:
+        logger.warning(f'无法计算AUROC: {e}')
     
     # 为了进一步处理，返回有毒得分和排序的索引
     return poison_scores, sorted_inds, train_p[:, 0] 

--- a/ssl_backdoor/defenses/patchsearch/poison_classifier.py
+++ b/ssl_backdoor/defenses/patchsearch/poison_classifier.py
@@ -460,7 +460,7 @@ def test(test_loader, model, args):
     
     # Calculate metrics
     if len(np.unique(gt_is_poison)) > 1:
-        tn, fp, fn, tp = confusion_matrix(gt_is_poison, pred_is_poison).ravel()
+        tn, fp, fn, tp = confusion_matrix(gt_is_poison, pred_is_poison, labels=[0, 1]).ravel()
         
         tpr = tp / (tp + fn) if (tp + fn) > 0 else 0.0
         fpr = fp / (fp + tn) if (fp + tn) > 0 else 0.0

--- a/ssl_backdoor/defenses/patchsearch/utils/clustering.py
+++ b/ssl_backdoor/defenses/patchsearch/utils/clustering.py
@@ -31,10 +31,10 @@ def faiss_kmeans(train_feats, nmb_clusters):
     clus.max_points_per_centroid = 10000000
 
     index = faiss.IndexFlatL2(d)
-    co = faiss.GpuMultipleClonerOptions()
-    co.useFloat16 = True
-    co.shard = True
-    index = faiss.index_cpu_to_all_gpus(index, co)
+    # co = faiss.GpuMultipleClonerOptions()
+    # co.useFloat16 = True
+    # co.shard = True
+    # index = faiss.index_cpu_to_all_gpus(index, co)
 
     # 执行训练
     clus.train(train_feats, index)

--- a/ssl_backdoor/utils/log_utils.py
+++ b/ssl_backdoor/utils/log_utils.py
@@ -1,0 +1,55 @@
+import sys
+import os
+import time
+
+class TeeLogger(object):
+    """
+    A simple logger that redirects stdout/stderr to both terminal and a file.
+    Designed to capture all print() outputs without modifying existing code.
+    This is necessary because Python's standard logging module does not automatically 
+    capture print() statements, and modifying all print() calls in legacy code is often impractical.
+    """
+    def __init__(self, filename):
+        self.terminal = sys.stdout
+        # Use line buffering or unbuffered if possible, but "a" mode text file is standard
+        self.log = open(filename, "a", encoding='utf-8')
+
+    def write(self, message):
+        self.terminal.write(message)
+        self.log.write(message)
+        self.log.flush() # Ensure logs are written immediately
+
+    def flush(self):
+        self.terminal.flush()
+        self.log.flush()
+
+    def close(self):
+        if self.log:
+            self.log.close()
+
+def setup_logging(output_dir, experiment_name="log"):
+    """
+    Sets up logging to file and stdout.
+    
+    Args:
+        output_dir (str): Directory to save log files.
+        experiment_name (str): Prefix for the log file name.
+        
+    Returns:
+        tuple: (log_path, experiment_id)
+    """
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    experiment_id = time.strftime("%Y%m%d_%H%M%S")
+    log_path = os.path.join(output_dir, f"{experiment_name}_{experiment_id}.txt")
+    
+    print(f"Logs will be saved to {log_path}")
+    
+    # Redirect stdout and stderr
+    # We only redirect if it hasn't been redirected yet to avoid nested loops if called multiple times
+    if not isinstance(sys.stdout, TeeLogger):
+        sys.stdout = TeeLogger(log_path)
+        sys.stderr = sys.stdout
+    
+    return log_path, experiment_id

--- a/tools/run_patchsearch.py
+++ b/tools/run_patchsearch.py
@@ -5,10 +5,14 @@ PatchSearch防御方法的使用示例。
 import os
 import argparse
 import logging
+import torch
+from argparse import Namespace
+from torch.utils.data import DataLoader, ConcatDataset
 
 from ssl_backdoor.defenses.patchsearch import run_patchsearch, run_patchsearch_filter
-from ssl_backdoor.ssl_trainers.trainer import create_data_loader
 from ssl_backdoor.ssl_trainers.utils import load_config
+from ssl_backdoor.datasets.dataset import OnlineUniversalPoisonedValDataset, FileListDataset
+from ssl_backdoor.defenses.patchsearch.utils.dataset import get_transforms
 
 
 def parse_args():
@@ -18,14 +22,10 @@ def parse_args():
     parser = argparse.ArgumentParser(description='PatchSearch防御示例')
     parser.add_argument('--config', type=str, required=True,
                         help='基础配置文件路径，支持.py或.yaml格式')
-    parser.add_argument('--attack_config', type=str, required=True,
-                        help='后门攻击配置文件路径 (.yaml格式)')
-    parser.add_argument('--output_dir', type=str, default=None,
-                        help='输出目录（可选，优先使用配置文件中的路径）')
-    parser.add_argument('--experiment_id', type=str, default=None,
-                        help='实验ID（可选，优先使用配置文件中的值）')
-    parser.add_argument('--skip_filter', action='store_true',
-                        help='是否跳过过滤步骤')
+    # Add optional arguments to override config
+    parser.add_argument('--output_dir', type=str, help='输出目录')
+    parser.add_argument('--experiment_id', type=str, help='实验ID')
+    parser.add_argument('--skip_filter', action='store_true', help='跳过第二阶段过滤')
     
     return parser.parse_args()
 
@@ -40,13 +40,7 @@ def main():
     print(f"加载基础配置文件: {args.config}")
     config = load_config(args.config)
     
-    # 2. 加载攻击配置（仅用于数据加载）
-    print(f"加载攻击配置文件: {args.attack_config}")
-    attack_config = load_config(args.attack_config)
-    if not isinstance(attack_config, dict):
-        raise ValueError(f"攻击配置文件 {args.attack_config} 格式错误")
-    
-    # 3. 命令行参数覆盖基础配置
+    # 2. 命令行参数覆盖基础配置
     if args.output_dir:
         config['output_dir'] = args.output_dir
     if args.experiment_id:
@@ -61,49 +55,137 @@ def main():
     print(f"数据集名称: {config.get('dataset_name', 'unknown')}")
     print(f"输出目录: {config.get('output_dir', '/workspace/SSL-Backdoor/results/defense')}")
     print(f"实验ID: {config.get('experiment_id', 'patchsearch_defense')}")
-    
-    # 使用create_data_loader加载有毒数据集，只使用attack_config
-    print("使用攻击配置加载有毒可疑数据集...")
-    if attack_config.get('save_poisons'):
-        print("save_poisons is True, 使用 PatchSearch 的训练文件初始化攻击配置的训练文件")
-        attack_config['poisons_saved_path'] = config['train_file']
-        attack_config['save_poisons'] = False
 
-    attack_config['distributed'] = False # 默认运行在单 GPU 上
-    attack_config['workers'] = config['num_workers'] # 默认缺失的配置从 PatchSearch 的配置中获取
-    attack_config['batch_size'] = config['batch_size'] # 默认缺失的配置从 PatchSearch 的配置中获取
+    # --- 构造外部测试集 (Clean + Poisoned) ---
+    external_test_loader = None
+    if 'poison_config_path' in config:
+        print(f"\n====== 构造外部测试集 (Balanced Clean + Poisoned) ======")
+        poison_config_path = config['poison_config_path']
+        print(f"加载毒化配置: {poison_config_path}")
+        poison_config = load_config(poison_config_path)
+        poison_args = Namespace(**poison_config)
 
-    print("检查 attack config", attack_config)
+        # 确保 dataset_name 一致
+        dataset_name = config.get('dataset_name', 'cifar10')
+        image_size = 32 if 'cifar' in dataset_name else 96 if 'stl' in dataset_name else 224
+        
+        # 获取 transforms
+        # 注意: OnlineUniversalPoisonedValDataset 需要 transforms 来做 resize 等
+        # 这里我们使用 patchsearch 的 get_transforms，通常是 ToTensor + Normalize
+        transform = get_transforms(dataset_name, image_size)
 
-    poison_dataset = None
-    # 如果想要从训练风格中加载有毒数据集，请取消注释以下代码
-    # # 将字典转换为Namespace对象
-    # attack_args = argparse.Namespace(**attack_config)
-    # poison_loader = create_data_loader(
-    #     attack_args  # 传递Namespace对象而不是字典
-    # )
-    # poison_dataset = poison_loader.dataset
+        # 1. Clean Test Set
+        clean_test_file = poison_config.get('test_file')
+        print(f"加载干净测试集: {clean_test_file}")
+        # 使用 FileListDataset 加载干净数据 (target=0 for binary classification in filter)
+        # 但是 FileListDataset 返回 (img, target) 其中 target 是原始类别
+        # 我们需要封装一下或者在 filter 中处理。
+        # run_poison_classifier 的 test 函数期望 DataLoader 返回 (path, images, target, is_poisoned, idx)
+        # PoisonDataset/ValPoisonDataset 返回这种格式。
+        # 这里我们需要构造兼容的 Dataset。
+        
+        # 实际上，我们可以重用 PoisonDataset 或者类似结构。
+        # 但为了简单，我们可以使用 OnlineUniversalPoisonedValDataset 的 'clean' 模式
+        
+        # 构造 clean_args
+        clean_args = Namespace(**poison_config)
+        clean_args.attack_algorithm = 'clean' # 强制为 clean
+        
+        clean_dataset = OnlineUniversalPoisonedValDataset(
+            clean_args,
+            path_to_txt_file=clean_test_file,
+            transform=transform
+        )
+        # OnlineUniversalPoisonedValDataset 返回 (img, target)。
+        # 且在 __getitem__ 中: 
+        # if idx in self.poison_idxs: apply_poison
+        # 
+        # 等等，run_poison_classifier 的 test 函数:
+        # for i, (_, images, _, is_poisoned, inds) in enumerate(test_loader):
+        # 它解包5个值。
+        # 而 OnlineUniversalPoisonedValDataset 默认返回 (img, target) 除非 rich_output=True。
+        
+        clean_dataset.rich_output = True # 设置 rich_output
+        # 但是 OnlineUniversalPoisonedValDataset 的 rich_output 返回 dict。
+        # test 函数期望 tuple unpacking。
+        
+        # 我们必须适配 test 函数的接口。
+        # ssl_backdoor/defenses/patchsearch/poison_classifier.py 中的 test 函数:
+        # for i, (_, images, _, is_poisoned, inds) in enumerate(test_loader):
+        # 这看起来是期望 ValPoisonDataset 的输出: image_path, img, target, is_poisoned, idx
+        
+        # 我们需要一个 Wrapper Dataset
+        class WrapperDataset(torch.utils.data.Dataset):
+            def __init__(self, dataset, is_poisoned_flag, offset=0):
+                self.dataset = dataset
+                self.is_poisoned_flag = is_poisoned_flag
+                self.offset = offset
+            
+            def __getitem__(self, idx):
+                # dataset 返回 (img, target) 或者 dict
+                # OnlineUniversalPoisonedValDataset 如果 rich_output=False 返回 (img, target)
+                res = self.dataset[idx]
+                if isinstance(res, dict):
+                    img = res['img']
+                    # path = res['img_path']
+                else:
+                    img, _ = res
+                    
+                # 构造 path (dummy), img, target (dummy), is_poisoned, idx
+                return "dummy_path", img, 0, self.is_poisoned_flag, idx + self.offset
+            
+            def __len__(self):
+                return len(self.dataset)
+
+        # 重新构造 Clean Dataset
+        clean_dataset = OnlineUniversalPoisonedValDataset(
+            clean_args,
+            path_to_txt_file=clean_test_file,
+            transform=transform
+        )
+        clean_wrapper = WrapperDataset(clean_dataset, is_poisoned_flag=False)
+
+        # 2. Poisoned Test Set
+        poisoned_dataset = OnlineUniversalPoisonedValDataset(
+            poison_args,
+            path_to_txt_file=clean_test_file, # 使用相同的文件列表，但在加载时投毒
+            transform=transform
+        )
+        poisoned_wrapper = WrapperDataset(poisoned_dataset, is_poisoned_flag=True, offset=len(clean_dataset))
+        
+        # Combine
+        combined_dataset = ConcatDataset([clean_wrapper, poisoned_wrapper])
+        
+        external_test_loader = DataLoader(
+            combined_dataset,
+            batch_size=config.get('batch_size', 64),
+            shuffle=False,
+            num_workers=config.get('num_workers', 8),
+            pin_memory=True
+        )
+        print(f"外部测试集构造完成，总样本数: {len(combined_dataset)} (Clean: {len(clean_dataset)}, Poisoned: {len(poisoned_dataset)})")
+
     
     # 运行PatchSearch防御，只使用基础配置
     results = run_patchsearch(
         args=config,  # 传递基础配置
         weights_path=config['weights_path'],
-        suspicious_dataset=poison_dataset,  # 传递加载的有毒数据集
+        suspicious_dataset=None,  # 传递加载的有毒数据集
         train_file=config['train_file'],
         dataset_name=config.get('dataset_name', 'imagenet100'),
         output_dir=config.get('output_dir', '/tmp'),
         arch=config.get('arch', 'resnet18'),
         num_clusters=config.get('num_clusters', 100),
         window_w=config.get('window_w', 60),
+        repeat_patch=config.get('repeat_patch', 1),
+        samples_per_iteration=config.get('samples_per_iteration', 2),
+        remove_per_iteration=config.get('remove_per_iteration', 0.25),
+        prune_clusters=config.get('prune_clusters', True),
+        test_images_size=config.get('test_images_size', 1000),
         batch_size=config.get('batch_size', 64),
-        use_cached_feats=config.get('use_cached_feats', False),
-        use_cached_poison_scores=config.get('use_cached_poison_scores', False),
-        experiment_id=config.get('experiment_id', 'patchsearch_defense')
+        topk_thresholds=config.get('topk_thresholds', [5, 10, 20, 50, 100, 500]),
+        experiment_id=config.get('experiment_id', 'patchsearch_defense'),
     )
-    
-    if "status" in results and results["status"] == "CACHED_FEATURES":
-        print("\n特征已缓存。请再次运行此脚本，但在基础配置文件中设置use_cached_feats=True以使用缓存的特征。")
-        return
     
     # 打印最有可能的有毒样本
     print("\n最有可能的前10个有毒样本的索引:")
@@ -112,6 +194,34 @@ def main():
         print(f"#{i+1}: 索引 {idx}, 毒性得分 {results['poison_scores'][idx]:.2f}, 实际是否有毒: {is_poison}")
     
     # 如果不跳过过滤步骤，则运行毒药分类器进行过滤
+    # 注意：run_patchsearch 内部也会调用 run_patchsearch_filter 如果提供了 args['filter'] 且没有 skip_filter
+    # 但是我们修改了 run_patchsearch 的签名来接受 external_test_loader 并传递给 run_patchsearch_filter
+    # 所以这里其实不需要再次手动调用 run_patchsearch_filter，除非 run_patchsearch 没调用它。
+    
+    # 查看 run_patchsearch 代码 (in __init__.py):
+    # 它确实只在 args 中有 'filter' 且 !skip_filter 时调用。
+    # 我们的 config 有 'filter' key (见 patchsearch.py).
+    # 所以 run_patchsearch 会处理一切。
+    
+    # 这里的代码块 (lines 78-130 in original) 似乎是多余的或者是手动调用的逻辑？
+    # 原代码 run_patchsearch 并没有调用 run_patchsearch_filter!
+    # 让我再检查一下 __init__.py。
+    
+    # 在 __init__.py 中，run_patchsearch 函数只返回了 result_dict。并没有调用 run_patchsearch_filter。
+    # wait, my previous read of __init__.py showed run_patchsearch logic.
+    # Lines 43-172 of __init__.py (run_patchsearch definition).
+    # It calculates scores and returns result_dict.
+    # It DOES NOT call run_patchsearch_filter.
+    
+    # So the original tools/run_patchsearch.py manually calls run_patchsearch_filter.
+    # My previous thought about "pass it to run_patchsearch_filter" via "run_patchsearch" was based on a misunderstanding or misreading if I thought run_patchsearch called it.
+    
+    # Looking at __init__.py again (from my Read):
+    # run_patchsearch ends at line 172.
+    # It does NOT call filter.
+    
+    # So I must update the MANUAL call to run_patchsearch_filter in tools/run_patchsearch.py.
+    
     if not args.skip_filter and 'filter' in config:
         print("\n====== 第二阶段：运行毒药分类器过滤 ======")
         
@@ -138,7 +248,8 @@ def main():
             weight_decay=filter_config.get('weight_decay', 1e-4),
             print_freq=filter_config.get('print_freq', 10),
             eval_freq=filter_config.get('eval_freq', 50),
-            seed=filter_config.get('seed', 42)
+            seed=filter_config.get('seed', 42),
+            external_test_loader=external_test_loader # 传递我们构造的 loader
         )
         
         # 评估过滤结果
@@ -167,4 +278,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main() 
+    main()


### PR DESCRIPTION
- Added AUROC calculation to the PatchSearch defense method for improved performance evaluation.
- Updated the run_patchsearch and patchsearch_iterative functions to include external test loader support.
- Refactored the poison classifier to log additional metrics, including TPR, FPR, and precision.
- Introduced a logging utility to capture stdout and stderr for better traceability during experiments.
- Cleaned up unused parameters and improved code structure for clarity and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AUROC and richer metrics, supports external clean+poisoned evaluation, simplifies clustering/caching to CPU K-means, avoids OOM, and introduces tee logging.
> 
> - **PatchSearch core (`ssl_backdoor/defenses/patchsearch`)**:
>   - Compute and log `AUROC` in `run_patchsearch` and `patchsearch_iterative`; include in results.
>   - Remove feature/poison score caching flags and fast-clustering path; always run FAISS K-means (CPU); drop GPU FAISS usage.
>   - Batch backbone inference when evaluating candidate patches to avoid OOM.
>   - Adjust model loading (`get_backbone_model(..., device='cpu', dataset=..., freeze_backbone=True)`).
> - **Poison classifier (`poison_classifier.py`)**:
>   - Log TPR (recall), FPR, precision, and `AUROC`; update `test()` to output probabilities and metrics.
>   - Wire `external_test_loader` through training/eval; optional external evaluation run.
>   - Seed with `set_seed`; minor dataset/validation plumbing.
> - **CLI/tools (`tools/run_patchsearch.py`)**:
>   - Build balanced external Clean+Poisoned test loader via `OnlineUniversalPoisonedValDataset` wrappers; pass to `run_patchsearch_filter`.
>   - Simplify CLI (no separate attack config); forward config overrides; keep manual filter stage call.
> - **Utils**:
>   - New tee logging utility `ssl_backdoor/utils/log_utils.py` to capture stdout/stderr.
>   - Model utils: switch to `load_checkpoint`, add `load_weights`; minor refactors in clustering (`utils/clustering.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcfff8c723c3f835920911d714fd596bb7f03bb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->